### PR TITLE
[Feature] Add entry-exit times to fill shifts and remove randomness if 0 provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,10 @@ OPTIONS:
 
     -r, --randomness <RANDOMNESS>
             The amount of minutes for the shift clock in and out entropy. Also configurable via SHIFT_MINUTES_RANDOMNESS env variable.
+
+        --entryTime <ENTRY_TIME>
+            The default entry time you want to set to fill shifts. Also configurable via ENTRY_TIME env variable.
+        
+        --exitTime <EXIT_TIME>
+            The default exit time you want to set to fill shifts. Also configurable via EXIT_TIME env variable.
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,4 +18,6 @@ export const config = {
     "???",
   SHIFT_MINUTES_RANDOMNESS: args.minutesRandomness ||
     env.SHIFT_MINUTES_RANDOMNESS || 3,
+  ENTRY_TIME: args.entryTime || env.ENTRY_TIME || 8,
+  EXIT_TIME: args.exitTime || env.EXIT_TIME || 16
 };

--- a/src/factorial.ts
+++ b/src/factorial.ts
@@ -28,6 +28,20 @@ cli
     },
   )
   .option(
+    "--entryTime <entryTime>",
+    "Set your default entryTime to fill your shifts [example: 8]",
+    {
+      default: config.ENTRY_TIME
+    }
+  )
+  .option(
+    "--exitTime <exitTime>",
+    "Set your default exitTime to fill your shifts [example: 16]",
+    {
+      default: config.EXIT_TIME
+    }
+  )
+  .option(
     "--email <email>",
     "The email of your factorial account. Also configurable via FACTORIAL_USER_EMAIL env variable.",
     {
@@ -40,14 +54,14 @@ cli
   )
   .example("factorial fill-shifts --year 2021 --month 1 --randomness 5")
   .action(
-    ({ year, month, randomness, email, password = config.USER_PASSWORD }) => {
+    ({ year, month, randomness, entryTime, exitTime, email, password = config.USER_PASSWORD }) => {
       if (email === "???" || password === "???") {
         console.log("error: Missing email/password\n");
         console.log("For more information try --help");
         Deno.exit(1);
       }
 
-      return fillShifts(email, password, year, month, randomness);
+      return fillShifts(email, password, year, month, randomness, entryTime, exitTime);
     },
   );
 

--- a/src/fillShift.ts
+++ b/src/fillShift.ts
@@ -10,6 +10,8 @@ export async function fillShifts(
   year: number,
   month: number,
   randomness: number,
+  entryTime: number,
+  exitTime: number,
 ) {
   const client = HttpClientFetch.create(
     { baseURL: "https://api.factorialhr.com" },
@@ -71,18 +73,18 @@ export async function fillShifts(
   for (const day of calendar) {
     if (factorial.isLaborable(day) && factorial.isInThePast(day)) {
       const clockIn = {
-        hours: "08",
-        minutes: addRandomnessToTime(25, randomness).toString().padStart(
+        hours: entryTime ?? "08",
+        minutes: randomness == 0 ? "00" : addRandomnessToTime(25, randomness).toString().padStart(
           1,
           "0",
-        ),
+        )
       };
       const clockOut = {
-        hours: "16",
-        minutes: addRandomnessToTime(35, randomness).toString().padStart(
+        hours: exitTime ?? "16",
+        minutes: randomness == 0 ? "00" : addRandomnessToTime(35, randomness).toString().padStart(
           1,
           "0",
-        ),
+        ) 
       };
 
       console.log(


### PR DESCRIPTION
Hi 👋 first thing I'm in love with the tool 😊❤

I was thinking that could be a good idea having the option to provide users adding their default entry and exit times and also having the possibility of disabling randomness If this behavior is not wanted. 

I added: 
- `entryTime`
- `exitTime`
- Remove randomness in `clockIn `and `clockOut `if randomness value provided in the CLI is 0 so we can set up plain time values like 9:00 to 17:00 :) 

So you could be able to run from the CLI something like: 

`factorial fill-shifts --year 2021 --month 8 --entryTime 8 --exitTime 16 --randomness 0`

And will be getting something like: 

![image](https://user-images.githubusercontent.com/48065983/131266902-3c0eb15f-e4d6-40a5-b1b2-191eca55656e.png)


I'm not typescript/javascript expert in fact I'm not even used to this language 🤣,  just playing with the tool to see if that can work for my day by day and just trying to have some fun playing around with it :) If this is not useful can be closed. 

Again thank you for such an amazing tool 👏👏👏 specially for me that always forget bout filling my factorial 🤣🤣🤣🤣🤣